### PR TITLE
add gitpod setting

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,9 @@
+# List the start up tasks. Learn more https://www.gitpod.io/docs/config-start-tasks/
+tasks:
+  - init: yarn install # runs during prebuild
+    command: yarn dev
+  
+# List the ports to expose. Learn more https://www.gitpod.io/docs/config-ports/
+ports:
+  - port: 3000
+    onOpen: open-preview

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 This is a starter template for [Learn Next.js](https://nextjs.org/learn).
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/Tanishy/nextjs-blog)


### PR DESCRIPTION
If we put the button in README.md, the gitpod.io system that is useful for cloud development starts.